### PR TITLE
concurrent rabbitmq queue stats polling

### DIFF
--- a/rabbitmq.go
+++ b/rabbitmq.go
@@ -94,8 +94,8 @@ func worker(mutex *sync.Mutex, rmqc *rabbithole.Client, ms *metric.MetricSet, wo
 		}
 		for _, queue := range rs.Items {
 			vhostQueue := queue.Vhost + "/" + queue.Name
-			// We're using a mutex because the version of infra sdk uses map that is not threadsafe
-			mutex.Lock()
+			// fmt.Println(vhostQueue, queue.Messages) // uncomment to log queues stats
+			mutex.Lock() // We're using a mutex because the version of infra sdk uses map that is not threadsafe
 			ms.SetMetric(vhostQueue, queue.Messages, metric.GAUGE)
 			mutex.Unlock()
 		}

--- a/rabbitmq.go
+++ b/rabbitmq.go
@@ -94,7 +94,7 @@ func worker(mutex *sync.Mutex, rmqc *rabbithole.Client, ms *metric.MetricSet, wo
 		}
 		for _, queue := range rs.Items {
 			vhostQueue := queue.Vhost + "/" + queue.Name
-			// fmt.Println(vhostQueue, queue.Messages)
+			// We're using a mutex because the version of infra sdk uses map that is not threadsafe
 			mutex.Lock()
 			ms.SetMetric(vhostQueue, queue.Messages, metric.GAUGE)
 			mutex.Unlock()
@@ -144,6 +144,7 @@ func populateMetrics(ms *metric.MetricSet) {
 	}
 	var mutex = &sync.Mutex{}
 	// TODO allow QueueFetchWorkerCount to be configurable in boshrelease
+	// Should default to 1 in the boshrelease
 	workerCount := 4
 	if workerCount > qs.PageCount {
 		workerCount = qs.PageCount


### PR DESCRIPTION
This PR allows for fetching queue stats against rabbitmq concurrently

This is necessary for a rmq clusters with a large number of queues (8k+ in our case)

